### PR TITLE
Mathjax fixes

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -32,7 +32,7 @@ mathCtx = field "mathjax" $ \item -> do
   metadata <- getMetadata $ itemIdentifier item
   return ""
   return $ if isJust $ lookupString "mathjax" metadata
-           then "<script type=\"text/javascript\" src=\"http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML\"></script>"
+           then "<script type=\"text/javascript\" src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML\"></script>"
            else ""
 
 archiveCtx posts =

--- a/Main.hs
+++ b/Main.hs
@@ -15,6 +15,7 @@ import Hakyll
 import Text.Pandoc
 import Data.Monoid (mappend)
 import qualified Data.Map as M
+import Data.Maybe (isJust)
 
 --------------------------------------------------------------------
 -- Contexts
@@ -29,7 +30,8 @@ postCtx =
 mathCtx :: Context String
 mathCtx = field "mathjax" $ \item -> do
   metadata <- getMetadata $ itemIdentifier item
-  return $ if "mathjax" `M.member` metadata
+  return ""
+  return $ if isJust $ lookupString "mathjax" metadata
            then "<script type=\"text/javascript\" src=\"http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML\"></script>"
            else ""
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.16
+resolver: lts-9.10
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
First, the Metadata type has changed (jaspervdj/hakyll@e81468e0f64fdbe05794d5f8ccaebc00ee474ee2), then the Mathjax CDN url is [not valid any longer](https://www.mathjax.org/cdn-shutting-down/).